### PR TITLE
Drop simple-chalk dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -15,9 +15,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope-interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope-interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope-interface", "cloudpickle"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
@@ -263,7 +263,7 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl-flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -614,14 +614,6 @@ optional = false
 python-versions = "!=3.0,!=3.1,!=3.2,!=3.3,>=2.6"
 
 [[package]]
-name = "simple-chalk"
-version = "0.1.0"
-description = "A terminal string styling library"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -738,12 +730,12 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco-itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "8c4bd651e913d61c863f0d5db0007fc7e14b974a1f5cfb7f65813b14bfbd5dd8"
+content-hash = "d04cb8b7085432d4c60dac45ebd6452ca4823c3824e87b4c5dcb83c1c76ded51"
 
 [metadata.files]
 atomicwrites = [
@@ -1142,9 +1134,6 @@ secretstorage = [
 shellingham = [
     {file = "shellingham-1.4.0-py2.py3-none-any.whl", hash = "sha256:536b67a0697f2e4af32ab176c00a50ac2899c5a05e0d8e2dadac8e58888283f9"},
     {file = "shellingham-1.4.0.tar.gz", hash = "sha256:4855c2458d6904829bd34c299f11fdeed7cfefbf8a2c522e4caea6cd76b3171e"},
-]
-simple-chalk = [
-    {file = "simple_chalk-0.1.0.tar.gz", hash = "sha256:d80f55993dfa040c1b55d2fbfb925e4fbb5798c2934601aa448ef4a192d84196"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/poetry_exec_plugin/plugin.py
+++ b/poetry_exec_plugin/plugin.py
@@ -8,8 +8,6 @@ from cleo.application import Application
 from poetry.console.commands.env_command import EnvCommand
 from poetry.plugins.application_plugin import ApplicationPlugin
 
-from simple_chalk import dim, red
-
 from typing import Any, List
 
 
@@ -51,14 +49,13 @@ class ExecCommand(EnvCommand):
 
         if not cmd:
             self.line_error(
-                red(
-                    f"\nUnable to find the command '{cmd_name}'. To configure a command you must "
-                    "add it to your pyproject.toml under the path "
-                    "[tool.poetry-exec-plugin.commands]. For example:"
-                    "\n\n"
-                    "[tool.poetry-exec-plugin.commands]\n"
-                    f'{cmd_name} = "echo Hello World"\n'
-                )
+                f"\nUnable to find the command '{cmd_name}'. To configure a command you must "
+                "add it to your pyproject.toml under the path "
+                "[tool.poetry-exec-plugin.commands]. For example:"
+                "\n\n"
+                "[tool.poetry-exec-plugin.commands]\n"
+                f'{cmd_name} = "echo Hello World"\n',
+                style="error",
             )
             return 1
 
@@ -70,7 +67,7 @@ class ExecCommand(EnvCommand):
         # behaviour of npm/yarn.
         os.chdir(pyproject_folder_path)
 
-        self.line(dim(f"Exec: {full_cmd}\n"))
+        self.line(f"Exec: {full_cmd}\n", style="info")
         result = self.env.execute(*[shell, "-c", full_cmd])
 
         # NOTE: If running on mac or linux nothing will be executed after the previous line. This

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-exec-plugin"
-version = "0.3.3"
+version = "0.3.4"
 description = "A plugin for poetry that allows you to execute scripts defined in your pyproject.toml, just like you can in npm or pipenv."
 authors = ["keattang"]
 license = "MIT"
@@ -11,7 +11,6 @@ repository = "https://github.com/keattang/poetry-exec-plugin"
 [tool.poetry.dependencies]
 poetry = "^1.2.0.a2"
 python = "^3.7"
-simple-chalk = "^0.1.0"
 toml = "^0.10.2"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
[cleo library](https://cleo.readthedocs.io/) has [built-in support for terminal colors](https://cleo.readthedocs.io/en/latest/introduction.html#coloring-the-output), and already defines semantic styles, s.a, `info`, `comment`, `question` and `error`.

Using [self.line](https://github.com/python-poetry/cleo/blob/5cb93daa6978f3f54cb55c00b114cfd5ed4fb001/cleo/commands/command.py#L251) and [self.line_error](https://github.com/python-poetry/cleo/blob/5cb93daa6978f3f54cb55c00b114cfd5ed4fb001/cleo/commands/command.py#L267) `style` argument we can drop the dependency on [simple-chalk](https://github.com/olsonpm/py_simple-chalk) library, as it is only being used to display error messages in `red`, and info messages in `dim`.

Tested locally by pulling the plugin with `poetry self add https://github.com/ajcerejeira/poetry-exec-plugin.git`.

Here is how an info message is rendered under Gnome terminal:

![image](https://user-images.githubusercontent.com/22506305/177188328-1a3f5a25-9235-4fd2-bf6f-06303a9ddc7a.png)

And this is how an error message looks like:
![image](https://user-images.githubusercontent.com/22506305/177188383-b867e15a-1853-4cab-8a23-ce61050ad6fc.png)