### PR TITLE
changed TOML File access from `_file` to `file`

### DIFF
--- a/poetry_exec_plugin/plugin.py
+++ b/poetry_exec_plugin/plugin.py
@@ -36,7 +36,7 @@ class ExecCommand(EnvCommand):
     ]
 
     def handle(self) -> Any:
-        pyproject_folder_path = self.poetry.pyproject._file.path.parent
+        pyproject_folder_path = self.poetry.pyproject.file.path.parent
         pyproject_data = self.poetry.pyproject.data
 
         cmd_name = self.argument("cmd")


### PR DESCRIPTION
Hi, thanks for this useful plugin. I try to submit patch to fix this plugin on latest poetry.

Since Poetry 1.5, `TOMLFile` can no longer be referenced via `_file`, and `poetry exec` failed with an error(#14). Perhaps it recommended to use `file` instead of `_file`.

In Poetry 1.2.0, `PyProjectTOML` already had a `file` property, so perhaps this fix will not affect Poetry < 1.5, but I cannot be sure.

I have confirmed that `poetry exec` works with both Poetry 1.2.0 and 1.5.0 in my local environment.

(Sorry for my broken English!)